### PR TITLE
Update fids to use actual_off as reference time instead of now

### DIFF
--- a/fids/app.py
+++ b/fids/app.py
@@ -91,7 +91,6 @@ def get_busiest_airports() -> Response:
     """Get the busiest airport"""
     limit = request.args.get("limit", 10)
     query = request.args.get("query")
-    print(datetime.fromtimestamp(int(request.args.get("since", 0)), tz=UTC))
     since = int(request.args.get("since", 0))
     if query:
         result = flights_engine.execute(

--- a/fids/app.py
+++ b/fids/app.py
@@ -1,12 +1,13 @@
 """Read flight information from database and display it on a webpage"""
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import os
 import time
 from typing import Optional
 from flask import Flask, request, jsonify, abort, render_template, Response
 import sqlalchemy as sa  # type: ignore
 from sqlalchemy.sql import union, select, func, and_, or_  # type: ignore
+from sqlalchemy.sql.expression import text # type: ignore
 
 # pylint: disable=invalid-name
 flights_engine = sa.create_engine(os.environ["FLIGHTS_DB_URL"], echo=True)
@@ -50,8 +51,8 @@ def catch_all(path):
     """Render HTML"""
     # pylint: disable=unused-argument
     return render_template(
-        "index.html",
-        google_maps_api_key=os.environ.get("GOOGLE_MAPS_API_KEY", ""))
+        "index.html", google_maps_api_key=os.environ.get("GOOGLE_MAPS_API_KEY", "")
+    )
 
 
 @app.route("/positions/<flight_id>")
@@ -89,8 +90,9 @@ def get_flight(flight_id: Optional[str] = None) -> dict:
 def get_busiest_airports() -> Response:
     """Get the busiest airport"""
     limit = request.args.get("limit", 10)
-    since = datetime.fromtimestamp(int(request.args.get("since", 0)), tz=UTC)
     query = request.args.get("query")
+    print(datetime.fromtimestamp(int(request.args.get("since", 0)), tz=UTC))
+    since = int(request.args.get("since", 0))
     if query:
         result = flights_engine.execute(
             union(
@@ -109,7 +111,18 @@ def get_busiest_airports() -> Response:
             row.origin
             for row in flights_engine.execute(
                 select([flights.c.origin])
-                .where(func.coalesce(flights.c.actual_off, flights.c.actual_out) > since)
+                .where(
+                    func.coalesce(flights.c.actual_off, flights.c.actual_out)
+                    > (
+                        select(
+                            [
+                                func.datetime(
+                                    func.max(flights.c.actual_off), text(f"'-{since} hours'")
+                                )
+                            ]
+                        )
+                    )
+                )
                 .group_by(flights.c.origin)
                 .order_by(func.count().desc(), flights.c.origin)
                 .limit(limit)
@@ -122,7 +135,6 @@ def get_busiest_airports() -> Response:
 def airport_arrivals(airport: str) -> Response:
     """Get a list of arrivals for a certain airport"""
     airport = airport.upper()
-    dropoff = datetime.now(tz=UTC) - timedelta(hours=5)
     result = flights_engine.execute(
         flights.select().where(
             and_(
@@ -130,7 +142,7 @@ def airport_arrivals(airport: str) -> Response:
                 flights.c.flight_number != "BLOCKED",
                 func.coalesce(flights.c.actual_out, flights.c.actual_off) is not None,
                 func.coalesce(flights.c.actual_in, flights.c.actual_on, flights.c.cancelled)
-                > dropoff,
+                > (select([func.datetime(func.max(flights.c.actual_off), text(f"'-5 hours'"))])),
             )
         )
     )
@@ -143,13 +155,13 @@ def airport_arrivals(airport: str) -> Response:
 def airport_departures(airport: str) -> Response:
     """Get a list of departures for a certain airport"""
     airport = airport.upper()
-    dropoff = datetime.now(tz=UTC) - timedelta(hours=5)
     result = flights_engine.execute(
         flights.select().where(
             and_(
                 flights.c.origin == airport,
                 flights.c.flight_number != "BLOCKED",
-                func.coalesce(flights.c.actual_out, flights.c.actual_off) > dropoff,
+                func.coalesce(flights.c.actual_out, flights.c.actual_off)
+                > (select([func.datetime(func.max(flights.c.actual_off), text(f"'-5 hours'"))])),
             )
         )
     )
@@ -164,8 +176,6 @@ def airport_departures(airport: str) -> Response:
 def airport_enroute(airport: str) -> Response:
     """Get a list of flights enroute to a certain airport"""
     airport = airport.upper()
-    past_dropoff = datetime.now(tz=UTC) - timedelta(hours=5)
-    future_dropoff = datetime.now(tz=UTC) + timedelta(hours=6)
     result = flights_engine.execute(
         flights.select().where(
             and_(
@@ -173,7 +183,10 @@ def airport_enroute(airport: str) -> Response:
                 flights.c.flight_number != "BLOCKED",
                 func.coalesce(flights.c.actual_in, flights.c.actual_on, flights.c.cancelled)
                 == None,
-                flights.c.estimated_on.between(past_dropoff, future_dropoff),
+                flights.c.estimated_on.between(
+                    select([func.datetime(func.max(flights.c.actual_off), text(f"'-5 hours'"))]),
+                    select([func.datetime(func.max(flights.c.actual_off), text(f"'+6 hours'"))]),
+                ),
             )
         )
     )
@@ -187,8 +200,6 @@ def airport_enroute(airport: str) -> Response:
 def airport_scheduled(airport: str) -> Response:
     """Get a list of scheduled flights from a certain airport"""
     airport = airport.upper()
-    past_dropoff = datetime.now(tz=UTC) - timedelta(hours=5)
-    future_dropoff = datetime.now(tz=UTC) + timedelta(hours=6)
     result = flights_engine.execute(
         flights.select().where(
             and_(
@@ -199,10 +210,21 @@ def airport_scheduled(airport: str) -> Response:
                     # You can actually get true_cancel'ed flights with an actual_out/off. Weird?
                     flights.c.true_cancel,
                 ),
-                flights.c.scheduled_off.between(past_dropoff, future_dropoff),
+                flights.c.scheduled_off.between(
+                    select([func.datetime(func.max(flights.c.actual_off), text(f"'-5 hours'"))]),
+                    select([func.datetime(func.max(flights.c.actual_off), text(f"'+6 hours'"))]),
+                ),
                 or_(
                     flights.c.cancelled == None,
-                    and_(flights.c.true_cancel, flights.c.cancelled > past_dropoff),
+                    and_(
+                        flights.c.true_cancel,
+                        flights.c.cancelled
+                        > (
+                            select(
+                                [func.datetime(func.max(flights.c.actual_off), text(f"'-5 hours'"))]
+                            )
+                        ),
+                    ),
                 ),
             )
         )

--- a/fids/frontend/client/src/components/LandingPage/AirportList.js
+++ b/fids/frontend/client/src/components/LandingPage/AirportList.js
@@ -8,7 +8,7 @@ class AirportList extends Component {
     state = {
         topAirports: [],
         loading: true,
-        since: 60 * 60 * 1000
+        since: 1
     }
 
     componentDidMount() {
@@ -16,11 +16,7 @@ class AirportList extends Component {
     }
 
     fetchTopAirports(time) {
-
-        const now = Date.now();
-        const timeAgo = Math.floor((now - time) / 1000);
-
-        axios.get(`/airports/?limit=10&since=${timeAgo}`)
+        axios.get(`/airports/?limit=10&since=${time}`)
             .then(response => {
                 this.setState({
                     topAirports: response.data,
@@ -44,11 +40,11 @@ class AirportList extends Component {
 
         const timeIntervalText = (since) => {
             switch (since) {
-                case (60 * 60 * 1000):
+                case 1:
                     return "1 hour"
-                case ((60 * 60 * 1000) * 12):
+                case 12:
                     return "12 hours"
-                case ((60 * 60 * 1000) * 24):
+                case 24:
                     return "24 hours"
                 default:
                     return since
@@ -79,9 +75,9 @@ class AirportList extends Component {
                 </Container>
                 <Container className="radio-button-container">
                         <ButtonGroup className="w-100" toggle>
-                            <ToggleButton onChange={() => this.onRadioClick(60 * 60 * 1000)} type="radio" name="since" defaultChecked value={60 * 60 * 1000}>1 hour</ToggleButton>
-                            <ToggleButton onChange={() => this.onRadioClick((60 * 60 * 1000) * 12)} type="radio" name="since" value={(60 * 60 * 1000) * 12}>12 hours</ToggleButton>
-                            <ToggleButton onChange={() => this.onRadioClick((60 * 60 * 1000) * 24)} type="radio" name="since" value={(60 * 60 * 1000) * 24}>24 hours</ToggleButton>
+                            <ToggleButton onChange={() => this.onRadioClick(1)} type="radio" name="since" defaultChecked value={1}>1 hour</ToggleButton>
+                            <ToggleButton onChange={() => this.onRadioClick(12)} type="radio" name="since" value={12}>12 hours</ToggleButton>
+                            <ToggleButton onChange={() => this.onRadioClick(24)} type="radio" name="since" value={24}>24 hours</ToggleButton>
                         </ButtonGroup>
                 </Container>
                 </>


### PR DESCRIPTION
We should use max(actual_off) for the reference time to determine what flights we should display on airport pages. This accounts to the situation where we are receiving a firehose feed with data in the past.