### PR TITLE
Additional checks for kafka readiness

### DIFF
--- a/connector/main.py
+++ b/connector/main.py
@@ -292,6 +292,7 @@ async def main():
                 value="",
             )
         except KafkaException as error:
+            producer = None
             print(f"Kafka isn't available ({error}), trying again in a few seconds")
             time.sleep(3)
 


### PR DESCRIPTION
* Explicitly set producer=None when exception occurs on initial connection
* Handle `INVALID_REPLICATION_FACTOR` errors